### PR TITLE
Disable ANSI escape sequences in imvujstest on Win32

### DIFF
--- a/bin/node-runner.js
+++ b/bin/node-runner.js
@@ -73,10 +73,17 @@ function runTest(testPath, continuation) {
 
     var testPassed;
 
-    var green = '\x1b[32m',
-        red = '\x1b[31m',
-        yellow = '\x1b[33m',
-        normal = '\x1b[0m';
+    if (process.platform === 'win32') {
+        var green = '',
+            red = '',
+            yellow = '',
+            normal = '';
+    } else {
+        var green = '\x1b[32m',
+            red = '\x1b[31m',
+            yellow = '\x1b[33m',
+            normal = '\x1b[0m';
+    }
 
     // I'd use Object.create here but prototypes don't extend across
     // vm contexts in Node.js.  o_O Known issue with Node.js...


### PR DESCRIPTION
The imvujstest test runner for node uses ANSI escape sequences, but those don't work on Win32. This disables them when node.js is a Win32 process.
