### PR TITLE
Rejection handlers are always called, even when exposeErrors is true.

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -84,27 +84,27 @@ var IMVU = IMVU || {};
             init(new PromiseResolver(this));
         }
 
-        Promise.accept = function(value) {
+        Promise.accept = function(value, settings) {
             return new Promise(function(resolver) {
                 resolver.accept(value);
-            });
+            }, settings);
         };
 
-        function resolveWrap(value) {
+        function resolveWrap(value, settings) {
             return new Promise(function(resolver) {
                 resolver.resolve(value);
-            });
+            }, settings);
         }
 
         Promise.resolve = resolveWrap;
 
-        Promise.reject = function(value) {
+        Promise.reject = function(value, settings) {
             return new Promise(function(resolver) {
                 resolver.reject(value);
-            });
+            }, settings);
         };
 
-        Promise.any = function(values) {
+        Promise.any = function(values, settings) {
             return new Promise(function(resolver) {
                 var length = values.length;
                 if (length === 0) {
@@ -115,12 +115,12 @@ var IMVU = IMVU || {};
                 var acceptCallback = resolver.resolve.bind(resolver);
                 var rejectCallback = resolver.reject.bind(resolver);
                 for (var i = 0; i < length; ++i) {
-                    resolveWrap(values[i]).then(acceptCallback, rejectCallback);
+                    resolveWrap(values[i], settings).then(acceptCallback, rejectCallback);
                 }
-            });
+            }, settings);
         };
 
-        Promise.every = function(values) {
+        Promise.every = function(values, settings) {
             return new Promise(function(resolver) {
                 var length = values.length;
                 if (0 === length) {
@@ -137,12 +137,12 @@ var IMVU = IMVU || {};
                             resolver.resolve(args); // per spec: synchronous=true
                         }
                     }.bind(undefined, i);
-                    resolveWrap(values[i]).then(acceptCallback, rejectCallback);
+                    resolveWrap(values[i], settings).then(acceptCallback, rejectCallback);
                 }
-            });
+            }, settings);
         };
 
-        Promise.some = function(values) {
+        Promise.some = function(values, settings) {
             return new Promise(function(resolver) {
                 var length = values.length;
                 if (0 === length) {
@@ -159,9 +159,9 @@ var IMVU = IMVU || {};
                             resolver.reject(args); // per spec: synchronous=true
                         }
                     }.bind(undefined, i);
-                    resolveWrap(values[i]).then(acceptCallback, rejectCallback);
+                    resolveWrap(values[i], settings).then(acceptCallback, rejectCallback);
                 }
-            });
+            }, settings);
         };
 
         function processCallbacks(callbacks, result, immediateCallbacks) {

--- a/src/imvujstest/assert.js
+++ b/src/imvujstest/assert.js
@@ -19,7 +19,7 @@ module({
         if (typeof selectorOrJQueryObject === 'string') {
             return 'Selector ' + formatTestValue(selectorOrJQueryObject);
         } else if (typeof selectorOrJQueryObject === 'object') {
-            return "'" + selectorOrJQueryObject[0] + "'";
+            return "'" + $(selectorOrJQueryObject)[0] + "'";
         }
         return undefined;
     }


### PR DESCRIPTION
Does not change test behavior.

## Regarding the [first commit](https://github.com/imvu/imvujs/pull/7/commits/592f3d8f32ddf0626f124719da7272d49da0e9c2):

For example, when using `assert.dom.notHasClass('foo', someDomElement)`, then instead of

```
'undefined' expected NOT to have class 'foo'
```

we'll get


```
'[object HTMLSomeElement]' expected NOT to have class 'foo'
```

## as for the [second commit](https://github.com/imvu/imvujs/pull/7/commits/2664f132e59477cde855f30d0082baa54dada7af):

Just adds to the API to allow settings to be passed to promises made with the static methods.

## as for the [third commit](https://github.com/imvu/imvujs/pull/7/commits/9f4302d81eae29da09e49584f0131238ac42df52):

The catch handler in `p.then(...).catch(handler)` will always fire, no matter the value of `exposeErrors` or `immediateCallbacks`.

There might possibly be code relying on the old behavior which would mean that `catch` handlers that weren't firing before will now fire. 

## tests

All of the alloy tests are passing except for https://localhost.imvu.com/runtests/async-test-trampoline.html?now=1483498873818#/common/restgraph/user.async-test.js, but I'm not yet sure if it's related. It tells me

```
Test Failed: Uncaught Exception: Uncaught AssertionError: Bad test setup. Failed to login user
```