### PR TITLE
Add a 'has' method to ServiceProvider.

### DIFF
--- a/src/ServiceProvider.js
+++ b/src/ServiceProvider.js
@@ -13,6 +13,10 @@ var IMVU = IMVU || {};
             return this.services[name];
         },
 
+        has: function(serviceName) {
+            return this.services.hasOwnProperty(serviceName);
+        },
+
         register: function(name, instance) {
             this.services[name] = instance;
         },

--- a/src/ServiceProvider.test.js
+++ b/src/ServiceProvider.test.js
@@ -20,6 +20,13 @@ fixture("ServiceProvider", function() {
         assert.equal(timer, instance.timer);
     });
 
+    test('test for the existence of a registered service using "has"', function() {
+        var testKey = 'ligatureDearly';
+        assert.false(this.sp.has(testKey));
+        this.sp.register(testKey, 'crete-energetically');
+        assert.true(this.sp.has(testKey));
+    });
+
     test("dependencies can be specified on prototypes too", function() {
         var service = {};
         this.sp.register('service', service);


### PR DESCRIPTION
The new 'has' method will return true if the provided key exists as a service, false otherwise.